### PR TITLE
fix(presets): fix kuzzle-elasticsearch preset timestamps not being dynamic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
       "peerDependencies": {
         "pino-elasticsearch": "^8.1.0",
         "pino-pretty": "^13.0.0",
-        "pino-transport-ecs": "^1.0.1"
+        "pino-transport-ecs": "^1.1.0"
       },
       "peerDependenciesMeta": {
         "pino-elasticsearch": {
@@ -11204,9 +11204,9 @@
       "license": "MIT"
     },
     "node_modules/pino-transport-ecs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pino-transport-ecs/-/pino-transport-ecs-1.0.1.tgz",
-      "integrity": "sha512-w3+997vQQY/23TynIpVYUXkb86SEAA7KvSZP4kVS2p1LtzVZnC85bEio+G0iabUEImJsE3o3dFkcPQEt0uFJ0A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pino-transport-ecs/-/pino-transport-ecs-1.1.0.tgz",
+      "integrity": "sha512-2+Y/GEq7Blmv+BZJ1u/4Yx0fAUkbvoLe8M/vpeFAr+ruR6dTyMVSTL/oDS3C2xIpP0k0c0AOnfDHBYHFL1L2AA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "pino-elasticsearch": "^8.1.0",
     "pino-pretty": "^13.0.0",
-    "pino-transport-ecs": "^1.0.1"
+    "pino-transport-ecs": "^1.1.0"
   },
   "peerDependenciesMeta": {
     "pino-elasticsearch": {

--- a/src/Presets.ts
+++ b/src/Presets.ts
@@ -66,8 +66,8 @@ export abstract class Presets {
           ? {
               _kuzzle_info: {
                 author: -1,
-                createdAt: new Date().toISOString(),
-                updatedAt: new Date().toISOString(),
+                createdAt: '{{ currentDate }}',
+                updatedAt: '{{ currentDate }}',
                 updater: -1,
               },
             }


### PR DESCRIPTION
## What does this PR do ?

Updates kuzzleio/pino-transport-ecs in order to fix the `_kuzzle_info`'s `createdAt` and `updatedAt` timestamps not being updated.
