### PR TITLE
feat: add file preset to log directly into a file or a file descriptor

### DIFF
--- a/doc/1/api/types/preset-options/index.md
+++ b/doc/1/api/types/preset-options/index.md
@@ -42,6 +42,25 @@ The default preset that outputs logs to the standard output.
   - Uses `pino/file` with destination to stdout
   - Default level is `info`
 
+### FilePresetOptions
+```typescript
+interface FilePresetOptions extends BasePresetOptions {
+  preset: 'file';
+  presetOptions: {
+    destination: string | number; // File path to write logs
+    mkdir?: boolean; // Whether to create directory if it doesn't exist (defaults to true)
+    append?: boolean; // Whether to append to file instead of overwriting (defaults to true)
+  };
+}
+```
+
+#### Properties
+
+- `destination`: File path where logs will be written (required). If a number is provided, it will be treated as a file descriptor (e.g., `1` for stdout and `2` for stderr).
+- `mkdir`: Whether to create the directory if it doesn't exist (defaults to true)
+- `append`: Whether to append to the file instead of overwriting (defaults to true)
+
+
 ### KuzzleElasticsearchPresetOptions
 
 ```typescript
@@ -100,6 +119,19 @@ Configures logging to Grafana Loki.
 const config = {
   preset: 'stdout',
   level: 'debug',
+};
+```
+
+### File Preset
+
+```typescript
+const config = {
+  preset: 'file',
+  presetOptions: {
+    destination: '/var/log/my-app.log',
+    mkdir: true, // Create directory if it doesn't exist
+    append: true, // Append to file instead of overwriting
+  },
 };
 ```
 

--- a/doc/1/guides/transport-configuration/index.md
+++ b/doc/1/guides/transport-configuration/index.md
@@ -16,7 +16,7 @@ The Kuzzle Logger supports various transport configurations to determine how and
 
 ```typescript
 interface TransportPresetOptions {
-  preset: 'stdout' | 'kuzzle-elasticsearch' | 'loki';
+  preset: 'stdout' | 'kuzzle-elasticsearch' | 'loki' | 'file';
   level?: string;
   presetOptions?: PresetSpecificOptions;
 }
@@ -65,6 +65,19 @@ interface TransportPipelineOptions {
 const logger = new KuzzleLogger({
   transport: {
     preset: 'stdout',
+  },
+});
+```
+
+### Using File Preset
+
+```typescript
+const logger = new KuzzleLogger({
+  transport: {
+    preset: 'file',
+    presetOptions: {
+      destination: '/var/log/my-app.log',
+    },
   },
 });
 ```

--- a/src/Presets.ts
+++ b/src/Presets.ts
@@ -123,6 +123,18 @@ export abstract class Presets {
         };
       }
 
+      case 'file': {
+        return {
+          level: transport.level ?? 'info',
+          options: {
+            destination: transport.presetOptions.destination,
+            mkdir: transport.presetOptions.mkdir ?? true,
+            append: transport.presetOptions.append ?? true,
+          },
+          target: 'pino/file',
+        };
+      }
+
       default: {
         throw new Error(`Unknown preset: ${preset}`);
       }

--- a/src/Presets.ts
+++ b/src/Presets.ts
@@ -127,9 +127,9 @@ export abstract class Presets {
         return {
           level: transport.level ?? 'info',
           options: {
+            append: transport.presetOptions.append ?? true,
             destination: transport.presetOptions.destination,
             mkdir: transport.presetOptions.mkdir ?? true,
-            append: transport.presetOptions.append ?? true,
           },
           target: 'pino/file',
         };

--- a/src/types/KuzzleLoggerPresets.ts
+++ b/src/types/KuzzleLoggerPresets.ts
@@ -39,9 +39,9 @@ export interface FilePresetOptions<TransportOptions = Record<string, any>>
   extends BasePresetOptions<TransportOptions> {
   preset: 'file';
   presetOptions: {
+    append?: boolean;
     destination: string | number;
     mkdir?: boolean;
-    append?: boolean;
   };
 }
 

--- a/src/types/KuzzleLoggerPresets.ts
+++ b/src/types/KuzzleLoggerPresets.ts
@@ -35,7 +35,18 @@ export interface LokiPresetOptions<TransportOptions = Record<string, any>>
   };
 }
 
+export interface FilePresetOptions<TransportOptions = Record<string, any>>
+  extends BasePresetOptions<TransportOptions> {
+  preset: 'file';
+  presetOptions: {
+    destination: string | number;
+    mkdir?: boolean;
+    append?: boolean;
+  };
+}
+
 export type TransportPresetOptions<TransportOptions = Record<string, any>> =
   | StdoutPresetOptions<TransportOptions>
   | KuzzleElasticsearchPresetOptions<TransportOptions>
-  | LokiPresetOptions<TransportOptions>;
+  | LokiPresetOptions<TransportOptions>
+  | FilePresetOptions<TransportOptions>;


### PR DESCRIPTION
## What does this PR do ?

Add a new preset for file logging called `file` and document it. It will allow users to have access to almost the same feature the previous kuzzle-plugin-logger provided for file logging
