### PR TITLE
feat(loki): allow to use the propsToLabels option on loki preset

### DIFF
--- a/doc/1/api/types/preset-options/index.md
+++ b/doc/1/api/types/preset-options/index.md
@@ -161,6 +161,7 @@ const config = {
     },
     batching: true,
     interval: 2000,
+    propsToLabels: ['nodeId', 'namespace'],
   },
 };
 ```

--- a/doc/1/guides/presets/index.md
+++ b/doc/1/guides/presets/index.md
@@ -69,6 +69,8 @@ Configures logging to Grafana Loki.
     host: string;           // Required - Loki host URL
     interval?: number;      // Defaults to 1000
     labels?: Record<string, string>;  // Custom labels
+    levelMap?: Record<number, string>; // Custom log level mapping
+    propsToLabels?: string[]; // Properties to extract as labels from log entries
   };
 }
 ```

--- a/src/Presets.ts
+++ b/src/Presets.ts
@@ -118,6 +118,7 @@ export abstract class Presets {
               50: 'error',
               60: 'fatal',
             },
+            propsToLabels: transport.presetOptions.propsToLabels ?? [],
           },
           target: 'pino-loki',
         };

--- a/src/types/KuzzleLoggerPresets.ts
+++ b/src/types/KuzzleLoggerPresets.ts
@@ -32,6 +32,7 @@ export interface LokiPresetOptions<TransportOptions = Record<string, any>>
     interval?: number;
     labels?: Record<string, string>;
     levelMap?: Record<number, string>;
+    propsToLabels?: string[];
   };
 }
 


### PR DESCRIPTION
## What does this PR do ?

Allow user to use the `propsToLabel` loki preset option (from `pino-loki`) to use logger/child logger props as labels (for example: the namespace or nodeId when using it with Kuzzle)

